### PR TITLE
Added support for dub packages (code.dlang.org)

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -6,6 +6,7 @@ import {bootstrapLoaded} from './bootstrap';
 import {Disposable, DocumentSelector, languages, commands} from 'vscode';
 import {NpmCodeLensProvider} from './providers/npmCodeLensProvider';
 import {BowerCodeLensProvider} from './providers/bowerCodeLensProvider';
+import {DubCodeLensProvider} from './providers/dubCodeLensProvider';
 import {updateDependencyCommand, updateDependenciesCommand} from './commands';
 import {AppConfiguration} from './models/appConfiguration';
 
@@ -25,6 +26,12 @@ export function activate(context) {
     pattern: '**/bower.json'
   };
 
+  const dubSelector = {
+    language: 'json',
+    scheme: 'file',
+    pattern: '**/dub.json'
+  };
+
   const config = new AppConfiguration();
 
   const disposables = [];
@@ -39,6 +46,13 @@ export function activate(context) {
     languages.registerCodeLensProvider(
       bowerSelector,
       new BowerCodeLensProvider(config)
+    )
+  );
+
+  disposables.push(
+    languages.registerCodeLensProvider(
+      dubSelector,
+      new DubCodeLensProvider(config)
     )
   );
 

--- a/src/providers/dubCodeLensProvider.d.ts
+++ b/src/providers/dubCodeLensProvider.d.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Peter Flannery. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import {
+  CodeLensProvider,
+  CancellationToken,
+  CodeLens
+} from 'vscode';
+import {AppConfiguration} from '../models/appConfiguration';
+import {AbstractCodeLensProvider} from './abstractCodeLensProvider';
+
+export class DubCodeLensProvider extends AbstractCodeLensProvider implements CodeLensProvider {
+  private packageDependencyKeys: string[];
+  constructor(appConfig: AppConfiguration);
+  provideCodeLenses(document, token: CancellationToken);
+  resolveCodeLens(codeLensItem: CodeLens, token: CancellationToken): Thenable<CodeLens>;
+}

--- a/src/providers/dubCodeLensProvider.js
+++ b/src/providers/dubCodeLensProvider.js
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Peter Flannery. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import {resolve} from '../common/di';
+import {PackageCodeLens} from '../models/packageCodeLens';
+import {AbstractCodeLensProvider} from './abstractCodeLensProvider';
+import {PackageCodeLensList} from '../lists/packageCodeLensList'
+
+export class DubCodeLensProvider extends AbstractCodeLensProvider {
+
+  constructor(config) {
+    super(config);
+    this.packageDependencyKeys = [
+      'dependencies',
+      'devDependencies',
+      'peerDependencies',
+      'optionalDependencies'
+    ];
+  }
+
+  provideCodeLenses(document, token) {
+    const jsonDoc = resolve.jsonParser.parse(document.getText());
+    const collector = new PackageCodeLensList(document);
+
+    if (jsonDoc === null || jsonDoc.root === null)
+      return [];
+
+    if (jsonDoc.validationResult.errors.length > 0)
+      return [];
+
+    jsonDoc.root.getChildNodes().forEach((node) => {
+      if (this.packageDependencyKeys.indexOf(node.key.value) !== -1) {
+        collector.addRange(node.value.getChildNodes());
+      }
+    });
+
+    return collector.list;
+  }
+
+  resolveCodeLens(codeLensItem, token) {
+    if (codeLensItem instanceof PackageCodeLens) {
+
+      // if (codeLensItem.parent === true) {
+      //   super.makeUpdateDependenciesCommand(codeLensItem);
+      //   return;
+      // }
+
+      if (codeLensItem.packageVersion === 'latest') {
+        super.makeLatestCommand(codeLensItem);
+        return;
+      }
+
+      if (codeLensItem.packageVersion === '~master') {
+        super.makeLatestCommand(codeLensItem);
+        return;
+      }
+
+      const queryUrl = `http://code.dlang.org/api/packages/${encodeURIComponent(codeLensItem.packageName)}/latest`;
+      return resolve.httpRequest.xhr({ url: queryUrl })
+        .then(response => {
+          if (response.status != 200)
+            return super.makeErrorCommand(
+              response.status,
+              response.responseText,
+              codeLensItem
+            );
+
+          const verionStr = JSON.parse(response.responseText);
+          if (typeof verionStr !== "string")
+            return super.makeErrorCommand(
+              -1,
+              "Invalid object returned from server",
+              codeLensItem
+            );
+
+          return super.makeVersionCommand(
+            codeLensItem.packageVersion,
+            verionStr,
+            codeLensItem
+          );
+        }, response => {
+          const respObj = JSON.parse(response.responseText);
+          return super.makeErrorCommand(
+            response.status,
+            respObj.statusMessage,
+            codeLensItem
+          );
+        });
+    }
+  }
+}

--- a/test/unit/extension.test.ts
+++ b/test/unit/extension.test.ts
@@ -3,3 +3,4 @@ require('./common/di.tests');
 require('./providers/abstractCodeLensProvider.tests');
 require('./providers/npmCodeLensProvider.tests');
 require('./providers/bowerCodeLensProvider.tests');
+require('./providers/dubCodeLensProvider.tests');

--- a/test/unit/providers/dubCodeLensProvider.tests.js
+++ b/test/unit/providers/dubCodeLensProvider.tests.js
@@ -1,0 +1,187 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Peter Flannery. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+const semver = require('semver');
+
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {register} from '../../../src/common/di';
+import {TestFixtureMap} from '../../testUtils';
+import {DubCodeLensProvider} from '../../../src/providers/dubCodeLensProvider';
+import {AppConfiguration} from '../../../src/models/appConfiguration';
+import {PackageCodeLens} from '../../../src/models/packageCodeLens';
+
+const jsonExt = vscode.extensions.getExtension('vscode.json');
+const jsonParser = require(jsonExt.extensionPath + '/server/out/jsonParser');
+
+describe("DubCodeLensProvider", () => {
+  const testPath = path.join(__dirname, '../../../..', 'test');
+  const fixturePath = path.join(testPath, 'fixtures');
+  const fixtureMap = new TestFixtureMap(fixturePath);
+
+  let testProvider;
+  let httpRequestMock = {};
+  let appConfigMock = new AppConfiguration();
+  let satisfyOnly;
+  let defaultVersionPrefix;
+  Object.defineProperty(appConfigMock, 'versionPrefix', { get: () => defaultVersionPrefix })
+  Object.defineProperty(appConfigMock, 'satisfyOnly', { get: () => satisfyOnly })
+
+  beforeEach(() => {
+    register('semver', semver);
+    register('jsonParser', jsonParser);
+    register('httpRequest', httpRequestMock);
+
+    // mock the config
+    satisfyOnly = false;
+    defaultVersionPrefix = '^';
+    testProvider = new DubCodeLensProvider(appConfigMock);
+  });
+
+  describe("provideCodeLenses", () => {
+
+    it("returns empty array when the document json is invalid", () => {
+      let fixture = fixtureMap.read('package-invalid.json');
+
+      let testDocument = {
+        getText: range => fixture.content
+      };
+
+      let codeLens = testProvider.provideCodeLenses(testDocument, null);
+      assert.ok(codeLens instanceof Array, "codeLens should be an array.");
+      assert.ok(codeLens.length === 0, "codeLens should be an empty array.");
+    });
+
+    it("returns empty array when the document text is empty", () => {
+      let testDocument = {
+        getText: range => ''
+      };
+
+      let codeLens = testProvider.provideCodeLenses(testDocument, null);
+      assert.ok(codeLens instanceof Array, "codeLens should be an array.");
+      assert.ok(codeLens.length === 0, "codeLens should be an empty array.");
+    });
+
+    it("returns empty array when the package has no dependencies", () => {
+      let fixture = fixtureMap.read('package-no-deps.json');
+
+      let testDocument = {
+        getText: range => fixture.content
+      };
+
+      let codeLens = testProvider.provideCodeLenses(testDocument, null);
+      assert.ok(codeLens instanceof Array, "codeLens should be an array.");
+      assert.ok(codeLens.length === 0, "codeLens should be an empty array.");
+    });
+
+    it("returns array of given dependencies to be resolved", () => {
+      let fixture = fixtureMap.read('package-with-deps.json');
+
+      let testDocument = {
+        getText: range => fixture.content,
+        positionAt: offset => new vscode.Position(0, 0),
+        fileName: fixture.basename
+      };
+
+      let codeLens = testProvider.provideCodeLenses(testDocument, null);
+      assert.ok(codeLens instanceof Array, "codeLens should be an array.");
+      assert.equal(codeLens.length, 4, "codeLens should be an array containing 4 items.");
+
+      codeLens.forEach((entry, index) => {
+        assert.equal(entry.packageName, `dep${index + 1}`, `dependency name should be dep${index + 1}.`);
+      });
+    });
+
+  });
+
+  describe("resolveCodeLens", () => {
+
+    it("passes url to httpRequest.xhr", done => {
+      const codeLens = new PackageCodeLens(null, null, 'SomePackage', '1.2.3', false);
+      httpRequestMock.xhr = options => {
+        assert.equal(options.url, 'http://code.dlang.org/api/packages/SomePackage/latest', "Expected httpRequest.xhr(options.url) but failed.");
+        done();
+        return Promise.resolve({
+          status: 200,
+          responseText: null
+        });
+      };
+      testProvider.resolveCodeLens(codeLens, null);
+    });
+
+    it("when dub does not return status 200 then codeLens should return ErrorCommand", done => {
+      const codeLens = new PackageCodeLens(null, null, 'SomePackage', '1.2.3', false);
+      httpRequestMock.xhr = options => {
+        return Promise.resolve({
+          status: 404,
+          responseText: 'Not found'
+        });
+      };
+
+      testProvider.resolveCodeLens(codeLens, null).then(result => {
+        assert.equal(result.command.title, 'Error 404. Not found', "Expected command.title failed.");
+        assert.equal(result.command.command, undefined);
+        assert.equal(result.command.arguments, undefined);
+        done();
+      });
+    });
+
+    it("when null response object returned from dub then codeLens should return ErrorCommand", done => {
+      const codeLens = new PackageCodeLens(null, null, 'SomePackage', '1.2.3', false);
+
+      httpRequestMock.xhr = options => {
+        return Promise.resolve({
+          status: 200,
+          responseText: null
+        });
+      };
+
+      testProvider.resolveCodeLens(codeLens, null).then(result => {
+        assert.equal(result.command.title, 'Error -1. Invalid object returned from server', "Expected command.title failed.");
+        assert.equal(result.command.command, undefined);
+        assert.equal(result.command.arguments, undefined);
+        done();
+      });
+
+    });
+
+    it("when response is an error object then codeLens should return ErrorCommand", done => {
+      const codeLens = new PackageCodeLens(null, null, 'SomePackage', '1.2.3', false);
+
+      httpRequestMock.xhr = options => {
+        return Promise.resolve({
+          status: 200,
+          responseText: '{"statusMessage": "Package not found"}'
+        });
+      };
+
+      testProvider.resolveCodeLens(codeLens, null).then(result => {
+        assert.equal(result.command.title, 'Error -1. Invalid object returned from server', "Expected command.title failed.");
+        assert.equal(result.command.command, undefined);
+        assert.equal(result.command.arguments, undefined);
+        done();
+      });
+    });
+
+    it("when a valid response returned from dub and package version is 'not latest' then codeLens should return NewVersionCommand", done => {
+      const codeLens = new PackageCodeLens(null, null, 'SomePackage', '1.2.3', false);
+      httpRequestMock.xhr = options => {
+        return Promise.resolve({
+          status: 200,
+          responseText: '"3.2.1"'
+        });
+      };
+      testProvider.resolveCodeLens(codeLens, null).then(result => {
+        assert.equal(result.command.title, '&uarr; ^3.2.1');
+        assert.equal(result.command.command, '_versionlens.updateDependencyCommand');
+        assert.equal(result.command.arguments[1], '"^3.2.1"');
+        done();
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
I wanted to include something similar in my D extension but because there is already a plugin for this, I am just going to add support here.

dub (code.dlang.org) is the package manager for the D programming language and its API is similar to NPMs API.

I implemented the test cases and the provider for dub. I volunteer for keeping the dub provider up to date, so if you implement something which should get implemented in all providers ping me for dub support (@WebFreak001)