### PR TITLE
Forcing spaces in vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 // Place your settings in this file to overwrite default and user settings.
 {
   "editor.tabSize": 2,
+  "editor.insertSpaces": true,
   "files.exclude": {
     "node_modules": true,
     "out": false // set this to true to hide the "out" folder with the compiled JS files


### PR DESCRIPTION
If you have your settings to force tabs by default like me, vscode would add tabs instead of spaces to the code. This will prevent that as the current code also only uses spaces.